### PR TITLE
Force flyway to use version 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# use latest flyway
-FROM flyway/flyway
+# use specific flyway version that supports MySQL 5.7
+FROM flyway/flyway:7
 
 USER root 
 


### PR DESCRIPTION
## Overview

This PR forces Flyway to version 7 because it is the last version that supports MySQL 5.7.